### PR TITLE
abs -> fabs

### DIFF
--- a/Classes/EasingTypes/PMTweenEasingElastic.m
+++ b/Classes/EasingTypes/PMTweenEasingElastic.m
@@ -34,7 +34,7 @@
             if (!period) {
                 period = duration * 0.3;
             }
-            if (amplitude < abs(valueDelta)) {
+            if (amplitude < fabs(valueDelta)) {
                 amplitude = valueDelta;
                 overshoot = period * 0.25;
             } else {
@@ -75,7 +75,7 @@
             if (!period) {
                 period = duration * 0.3;
             }
-            if (amplitude < abs(valueDelta)) {
+            if (amplitude < fabs(valueDelta)) {
                 amplitude = valueDelta;
                 overshoot = period * 0.25;
             } else {
@@ -114,7 +114,7 @@
             if (!period) {
                 period = duration * (0.3 * 1.5);
             }
-            if (amplitude < abs(valueDelta)) {
+            if (amplitude < fabs(valueDelta)) {
                 amplitude = valueDelta;
                 overshoot = period * 0.25;
             } else {

--- a/Classes/PMTweenUnit.m
+++ b/Classes/PMTweenUnit.m
@@ -668,7 +668,7 @@
 
         if (_tweenDirection == PMTweenDirectionForward) {
             new_value = self.easingBlock(elapsed_time, _startingValue, value_delta, adjusted_duration);
-            progress = fabsf((_currentValue - _startingValue) / value_delta);
+            progress = fabs((_currentValue - _startingValue) / value_delta);
 
         } else {
             
@@ -677,7 +677,7 @@
             } else {
                 new_value = self.easingBlock(elapsed_time, _endingValue, -value_delta, adjusted_duration);
             }
-            progress = fabsf((_currentValue - _endingValue) / value_delta);
+            progress = fabs((_currentValue - _endingValue) / value_delta);
 
         }
 

--- a/Examples/PMTweenExamples/Classes/AdditiveVC.m
+++ b/Examples/PMTweenExamples/Classes/AdditiveVC.m
@@ -55,7 +55,7 @@
     if (!self.createdUI) {
         CGFloat content_top = 0;
         if ([self respondsToSelector:@selector(topLayoutGuide)]) {
-            content_top = self.topLayoutGuide.length;
+            content_top = self.topLayoutGuide.length; // This is never used.
         }
         //self.tweenView.frame = CGRectMake(20, content_top+20, 50, 50);
         


### PR DESCRIPTION
Because warnings suck.

Also by the way `Examples/PMTweenExamples/Classes/AdditiveVC.m` gives a static analyser warning because a line of code is never used, why is it there anyways 😛
